### PR TITLE
fix: add lasmaw ssh key

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -114,7 +114,7 @@
       { startGid = 100000; count = 65536; }
     ];
     openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHcqZU5WYGvnE1o5cjyTjn9IELmTGGlcjVViGzVxi4i6 eddsa-key-20250403" 
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6OJMusrF25tNs3bHcSxxoXnNHmvSuaaGjkXo9VJ4CQ mateo.lachaize@gmail.com" 
     ];
   };
 

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -114,7 +114,7 @@
       { startGid = 100000; count = 65536; }
     ];
     openssh.authorizedKeys.keys = [
-      "rsa-key-20250319 AAAAB3NzaC1yc2EAAAADAQABAAABAQCQ2pIo0SYF1SHDIvII7G2mDdjQxHMh9qC/1PHA0Bbwbd1dfuhv3Z2E9iqYrv+sgKAgFn1Lyv1D4n6yfOrMACSzMkG9TLs6x0Cok148B34lFMW0wWsaJ5lDvhvPNDQpRYcV7ZfGwjY0bABvCUmVPNNNLb3GnndcIM5dQdWtIFrWgawQnS/ckREsIbJwM66tBC90mItyfcga0BCR7i4XLJfDliJLhpFTztNZNYmlhfKi3Ydu0pQ8Fsvj8vp1oH5pvLUDJzlk9W1D8s27U258QWyJz93wjdg6AaQW28/2WiVxnvsl+8hWpMFEiC8RYSvn1MTagicXQW59MrhOWMGUH+2F dudule" 
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHcqZU5WYGvnE1o5cjyTjn9IELmTGGlcjVViGzVxi4i6 eddsa-key-20250403" 
     ];
   };
 


### PR DESCRIPTION
This pull request updates the SSH authorized keys in the `hosts/default.nix` file. The change replaces an old RSA key with a new Ed25519 key.

Key update:

* [`hosts/default.nix`](diffhunk://#diff-9e2394d5d965447692e8b09d0235b8fdd8426071c2537d0e4a7e4786d9fcf97eL117-R117): Replaced the existing RSA key (`rsa-key-20250319`) with a new Ed25519 key associated with the email `mateo.lachaize@gmail.com`.