### PR TITLE
fix: missing separator in network specs

### DIFF
--- a/modules/services.nix
+++ b/modules/services.nix
@@ -78,7 +78,7 @@
             "/var/log/caddy:/var/log/caddy"
           ];
           extraOptions = [
-            "--network=${lib.concatMapStrings ({name, ...}: "${name}-network") config.theutis_services.services}"
+            "--network=${lib.concatStringsSep " " (map ({name, ...}: "${name}-network") config.theutis_services.services)}"
             "--name=caddy"
           ];
         };


### PR DESCRIPTION
This pull request includes a small update to the `modules/services.nix` file, improving how network strings are concatenated for service configuration.

* [`modules/services.nix`](diffhunk://#diff-cc064ae4795a90c907ebdbbedb606be8d2ecb1104f98c4f6b4031afe4bf6d1cbL81-R81): Replaced `lib.concatMapStrings` with `lib.concatStringsSep` to concatenate network names with a space separator, ensuring proper formatting in the `extraOptions` array.